### PR TITLE
use separate build tree for python versions

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -11,7 +11,7 @@ CLEANFILES = *~ constants.c *.so
 EXTRA_DIST = pwquality.c setup.py
 
 all-local:
-	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-lib=.
+	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV)
 
 install-exec-local:
-	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py install --prefix=${DESTDIR}${prefix}
+	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --prefix=${DESTDIR}${prefix}


### PR DESCRIPTION
added python patch to allow multiple python versions build without duplicating source tree.

originates from [pld-linux/libpwquality](https://github.com/pld-linux/libpwquality/commit/3cc44c3221f5702a7c38394bc63028eea18b8853)