### PR TITLE
Move retry, enforce_for_root, local_users_only options to pwquality.conf

### DIFF
--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -129,6 +129,26 @@ not created yet.
 
 Path to the cracklib dictionaries. Default is to use the cracklib default.
 
+=item B<retry=>I<N>
+
+Prompt user at most I<N> times before returning with error. The default is
+I<1>.
+
+=item B<enforce_for_root>
+
+The module will return error on failed check even if the user changing the
+password is root. This option is off by default which means that just
+the message about the failed check is printed but root can change
+the password anyway. Note that root is not asked for an old password
+so the checks that compare the old and new password are not performed.
+
+=item B<local_users_only>
+
+The module will not test the password quality for users that are not present
+in the F</etc/passwd> file. The module still asks for the password so
+the following modules in the stack can use the B<use_authtok> option.
+This option is off by default.
+
 =back
 
 =head1 SEE ALSO

--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -27,6 +27,9 @@ struct pwquality_settings {
         int dict_check;
         int user_check;
         int enforcing;
+        int retry_times;
+        int enforce_for_root;
+        int local_users_only;
         char *bad_words;
         char *dict_path;
 };
@@ -46,6 +49,9 @@ struct setting_mapping {
 #define PWQ_DEFAULT_DICT_CHECK   1
 #define PWQ_DEFAULT_USER_CHECK   1
 #define PWQ_DEFAULT_ENFORCING    1
+#define PWQ_DEFAULT_RETRY_TIMES  1
+#define PWQ_DEFAULT_ENFORCE_ROOT 0
+#define PWQ_DEFAULT_LOCAL_USERS  0
 
 #define PWQ_TYPE_INT             1
 #define PWQ_TYPE_STR             2

--- a/src/pwquality.conf
+++ b/src/pwquality.conf
@@ -61,3 +61,15 @@
 #
 # Path to the cracklib dictionaries. Default is to use the cracklib default.
 # dictpath =
+#
+# Prompt user at most N times before returning with error. The default is 1.
+# retry = 3
+#
+# Enforces pwquality checks on the root user password.
+# Enabled if the option is present.
+# enforce_for_root
+#
+# Skip testing the password quality for users that are not present in the
+# /etc/passwd file.
+# Enabled if the option is present.
+# local_users_only

--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -30,6 +30,9 @@ extern "C" {
 #define PWQ_SETTING_DICT_CHECK      15
 #define PWQ_SETTING_USER_CHECK      16
 #define PWQ_SETTING_ENFORCING       17
+#define PWQ_SETTING_RETRY_TIMES     18
+#define PWQ_SETTING_ENFORCE_ROOT    19
+#define PWQ_SETTING_LOCAL_USERS     20
 
 #define PWQ_MAX_ENTROPY_BITS       256
 #define PWQ_MIN_ENTROPY_BITS       56

--- a/src/settings.c
+++ b/src/settings.c
@@ -36,6 +36,9 @@ pwquality_default_settings(void)
         pwq->dict_check = PWQ_DEFAULT_DICT_CHECK;
         pwq->user_check = PWQ_DEFAULT_USER_CHECK;
         pwq->enforcing = PWQ_DEFAULT_ENFORCING;
+        pwq->retry_times = PWQ_DEFAULT_RETRY_TIMES;
+        pwq->enforce_for_root = PWQ_DEFAULT_ENFORCE_ROOT;
+        pwq->local_users_only = PWQ_DEFAULT_LOCAL_USERS;
 
         return pwq;
 }
@@ -68,7 +71,10 @@ static const struct setting_mapping s_map[] = {
  { "usercheck", PWQ_SETTING_USER_CHECK, PWQ_TYPE_INT},
  { "enforcing", PWQ_SETTING_ENFORCING, PWQ_TYPE_INT},
  { "badwords", PWQ_SETTING_BAD_WORDS, PWQ_TYPE_STR},
- { "dictpath", PWQ_SETTING_DICT_PATH, PWQ_TYPE_STR}
+ { "dictpath", PWQ_SETTING_DICT_PATH, PWQ_TYPE_STR},
+ { "retry", PWQ_SETTING_RETRY_TIMES, PWQ_TYPE_INT},
+ { "enforce_for_root", PWQ_SETTING_ENFORCE_ROOT, PWQ_TYPE_SET},
+ { "local_users_only", PWQ_SETTING_LOCAL_USERS, PWQ_TYPE_SET}
 };
 
 /* set setting name with value */
@@ -344,6 +350,12 @@ pwquality_set_int_value(pwquality_settings_t *pwq, int setting, int value)
         case PWQ_SETTING_ENFORCING:
                 pwq->enforcing = value;
                 break;
+        case PWQ_SETTING_RETRY_TIMES:
+                pwq->retry_times = value;
+        case PWQ_SETTING_ENFORCE_ROOT:
+                pwq->enforce_for_root = value;
+        case PWQ_SETTING_LOCAL_USERS:
+                pwq->local_users_only = value;
         default:
                 return PWQ_ERROR_NON_INT_SETTING;
         }
@@ -429,6 +441,15 @@ pwquality_get_int_value(pwquality_settings_t *pwq, int setting, int *value)
                 break;
         case PWQ_SETTING_ENFORCING:
                 *value = pwq->enforcing;
+                break;
+        case PWQ_SETTING_RETRY_TIMES:
+                *value = pwq->retry_times;
+                break;
+        case PWQ_SETTING_ENFORCE_ROOT:
+                *value = pwq->enforce_for_root;
+                break;
+        case PWQ_SETTING_LOCAL_USERS:
+                *value = pwq->local_users_only;
                 break;
         default:
                 return PWQ_ERROR_NON_INT_SETTING;


### PR DESCRIPTION
- retry, enforce_for_root, local_users_only options can now be configured in pwquality.conf
- Fixes RHBZ#1537240