### PR TITLE
Changes to allow building a tarball of the python extension

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include constants.c

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -4,22 +4,32 @@
 # See the end of the file for Copyright and License Information
 #
 
+import os
+
 from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext as _build_ext
+from distutils.command.sdist import sdist as _sdist
+
+def genconstants(headerfile, outputfile):
+    hf = open(headerfile, 'r')
+    of = open(outputfile, 'w')
+    of.write('/* This file is generated during build time from pwquality.h */\n\n')
+    for line in hf:
+            if line.startswith('#define PWQ_'):
+                    s = line.split()
+                    of.write('PyModule_AddIntConstant(module, "%s", %s);\n' % (s[1], s[2]))
 
 class build_ext(_build_ext):
-    def genconstants(self, headerfile, outputfile):
-        hf = open(headerfile, 'r')
-        of = open(outputfile, 'w')
-        of.write('/* This file is generated during build time from pwquality.h */\n\n')
-        for line in hf:
-                if line.startswith('#define PWQ_'):
-                        s = line.split()
-                        of.write('PyModule_AddIntConstant(module, "%s", %s);\n' % (s[1], s[2]))
-
     def run(self):
-        self.genconstants('../src/pwquality.h', 'constants.c')
+        if not os.path.exists('constants.c'):
+            genconstants('../src/pwquality.h', 'constants.c')
         _build_ext.run(self)
+
+class sdist(_sdist):
+    def run(self):
+        if not os.path.exists('constants.c'):
+            genconstants('../src/pwquality.h', 'constants.c')
+        _sdist.run(self)
 
 pwqmodule = Extension('pwquality',
             sources = ['pwquality.c'],
@@ -36,7 +46,7 @@ setup(
     url = 'http://fedorahosted.org/libpwquality',
     license = 'BSD or GPLv2+',
     ext_modules = [pwqmodule],
-    cmdclass = {'build_ext': build_ext}
+    cmdclass = {'build_ext': build_ext, 'sdist': sdist}
 )
 
 # Copyright (c) Red Hat, Inc, 2011


### PR DESCRIPTION
With these changes it is possible to do a `python setup.py sdist` in the
python subdirectory and create a tarball which can be pushed to pypi.

That will allow people to pip install the Python extension module for
libpwquality (for instance, if their distribution is not building the
extension for their version of python)

Example of building:
```
./autogen.sh
./configure
cd python
python setup.py sdist upload
```

Note that you'll need to setup pypi credentials before it will let you upload.

Example of installing:
```
pip3 install --user pwquality
```

I ran into this trying to test some software via travis ci.  Travis uses Ubuntu images and Debian/Ubuntu only has the python bindings built for Python2.  If this change is applied and the python bindings are uploaded to pypi, then people can use apt-get to install the library and header files and then pip install to put the pwquality python bindings onto those hosts.