### PR TITLE
include: include sys/types.h in pwquality.h

### DIFF
--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -10,6 +10,8 @@
 #ifndef PWQUALITY_H
 #define PWQUALITY_H
 
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
pwquality_strerror() uses size_t in the prototype, but pwquality.h
doesn't include sys/types.h is hence not self-sufficient. Fix that.