### PR TITLE
cracklib: return built-in cracklib dictionary when queried

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <dirent.h>
+#include <crack.h>
 
 #include "pwquality.h"
 #include "pwqprivate.h"
@@ -467,7 +468,10 @@ pwquality_get_str_value(pwquality_settings_t *pwq, int setting, const char **val
                 *value = pwq->bad_words;
                 break;
         case PWQ_SETTING_DICT_PATH:
-                *value = pwq->dict_path;
+                if (pwq->dict_path)
+                        *value = pwq->dict_path;
+                else
+                        *value = GetDefaultCracklibDict();
                 break;
         default:
                 return PWQ_ERROR_NON_STR_SETTING;


### PR DESCRIPTION
It's sometimes usuful to know the dictionary used by the cracklib
invocation hidden in libpwquality (for example to gracefully disable
such checks in some environments that lack the dictionary file
automatically). Right now, this is not queriable however, and
libpwquality only allows to query the setting configured in libpwquality
itself. Let's fix that and expose the cracklib built-in path, too, if
nothing was explicitly configured otherwise.