### PR TITLE
Add usersubstr check

### DIFF
--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -209,8 +209,8 @@ than 3 characters.
 =item B<usersubstr=>I<N>
 
 If greater than 3 (due to the minimum length in usercheck), check whether the
-password contains a substring of at least this many characters in some form.
-The default is 0, which means this check is disabled
+password contains a substring of at least I<N> length in some form.
+The default is 0, which means this check is disabled.
 
 =item B<enforcing=>I<N>
 

--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -206,6 +206,12 @@ contains the user name in some form. The default is 1 which means that
 this check is enabled. It is not performed for user names shorter
 than 3 characters.
 
+=item B<usersubstr=>I<N>
+
+If greater than 3 (due to the minimum length in usercheck), check whether the
+password contains a substring of at least this many characters in some form.
+The default is 0, which means this check is disabled
+
 =item B<enforcing=>I<N>
 
 If nonzero, reject the password if it fails the checks, otherwise

--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -114,7 +114,7 @@ than 3 characters. (default 1)
 =item B<usersubstr=>I<N>
 
 If greater than 3 (due to the minimum length in usercheck), check whether the
-password contains a substring of at least usersubstr length in some form.
+password contains a substring of at least I<N> length in some form.
 (default 0)
 
 =item B<enforcing=>I<N>

--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -111,6 +111,12 @@ If nonzero, check whether the password (with possible modifications)
 contains the user name in some form. It is not performed for user names shorter
 than 3 characters. (default 1)
 
+=item B<usersubstr=>I<N>
+
+If greater than 3 (due to the minimum length in usercheck), check whether the
+password contains a substring of at least usersubstr length in some form.
+(default 0)
+
 =item B<enforcing=>I<N>
 
 If nonzero, reject the password if it fails the checks, otherwise

--- a/src/check.c
+++ b/src/check.c
@@ -538,7 +538,6 @@ password_check(pwquality_settings_t *pwq,
                void **auxerror)
 {
         int rv = 0;
-        int sub_rv = 0;
         char *oldmono = NULL, *newmono, *wrapped = NULL;
         char *usermono = NULL;
 

--- a/src/check.c
+++ b/src/check.c
@@ -410,7 +410,6 @@ wordcheck(pwquality_settings_t *pwq, const char *new,
         return 0;
 }
 
-#include <stdio.h>
 static int
 usercheck(pwquality_settings_t *pwq, const char *new,
           char *user)

--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -26,6 +26,7 @@ struct pwquality_settings {
         int gecos_check;
         int dict_check;
         int user_check;
+        int user_substr;
         int enforcing;
         int retry_times;
         int enforce_for_root;
@@ -48,6 +49,7 @@ struct setting_mapping {
 #define PWQ_DEFAULT_OTH_CREDIT   0
 #define PWQ_DEFAULT_DICT_CHECK   1
 #define PWQ_DEFAULT_USER_CHECK   1
+#define PWQ_DEFAULT_USER_SUBSTR  0
 #define PWQ_DEFAULT_ENFORCING    1
 #define PWQ_DEFAULT_RETRY_TIMES  1
 #define PWQ_DEFAULT_ENFORCE_ROOT 0

--- a/src/pwquality.conf
+++ b/src/pwquality.conf
@@ -54,6 +54,10 @@
 # The check is enabled if the value is not 0.
 # usercheck = 1
 #
+# Length of substrings from the username to check for in the password
+# The check is enabled if the value is greater than 0 and usercheck is enabled.
+# usersubstr = 0
+#
 # Whether the check is enforced by the PAM module and possibly other
 # applications.
 # The new password is rejected if it fails the check and the value is not 0.

--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -35,6 +35,7 @@ extern "C" {
 #define PWQ_SETTING_RETRY_TIMES     18
 #define PWQ_SETTING_ENFORCE_ROOT    19
 #define PWQ_SETTING_LOCAL_USERS     20
+#define PWQ_SETTING_USER_SUBSTR     21
 
 #define PWQ_MAX_ENTROPY_BITS       256
 #define PWQ_MIN_ENTROPY_BITS       56

--- a/src/settings.c
+++ b/src/settings.c
@@ -36,6 +36,7 @@ pwquality_default_settings(void)
         pwq->oth_credit = PWQ_DEFAULT_OTH_CREDIT;
         pwq->dict_check = PWQ_DEFAULT_DICT_CHECK;
         pwq->user_check = PWQ_DEFAULT_USER_CHECK;
+        pwq->user_substr = PWQ_DEFAULT_USER_SUBSTR;
         pwq->enforcing = PWQ_DEFAULT_ENFORCING;
         pwq->retry_times = PWQ_DEFAULT_RETRY_TIMES;
         pwq->enforce_for_root = PWQ_DEFAULT_ENFORCE_ROOT;
@@ -70,6 +71,7 @@ static const struct setting_mapping s_map[] = {
  { "gecoscheck", PWQ_SETTING_GECOS_CHECK, PWQ_TYPE_INT},
  { "dictcheck", PWQ_SETTING_DICT_CHECK, PWQ_TYPE_INT},
  { "usercheck", PWQ_SETTING_USER_CHECK, PWQ_TYPE_INT},
+ { "usersubstr", PWQ_SETTING_USER_SUBSTR, PWQ_TYPE_INT},
  { "enforcing", PWQ_SETTING_ENFORCING, PWQ_TYPE_INT},
  { "badwords", PWQ_SETTING_BAD_WORDS, PWQ_TYPE_STR},
  { "dictpath", PWQ_SETTING_DICT_PATH, PWQ_TYPE_STR},
@@ -348,6 +350,9 @@ pwquality_set_int_value(pwquality_settings_t *pwq, int setting, int value)
                 break;
         case PWQ_SETTING_USER_CHECK:
                 pwq->user_check = value;
+                break;
+        case PWQ_SETTING_USER_SUBSTR:
+                pwq->user_substr = value;
                 break;
         case PWQ_SETTING_ENFORCING:
                 pwq->enforcing = value;


### PR DESCRIPTION
Check for substrings of N characters from the username. Potentially useful for sites with usernames like firstnamelastname or similar.
Also rename usercheck to "wordcheck" (and corresponding internal var names) since it's also used for arbitrary words :)

Signed-off-by: Danny Sauer <dsauer@suse.com>