### PR TITLE
Add --without-cracklib configure parameter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,12 +153,17 @@ fi
 AC_DEFINE_UNQUOTED(CONF_PATH_RANDOMDEV, "$opt_randomdev", [Random device path.])
 
 dnl Check for cracklib
+AC_ARG_ENABLE([cracklib-check],
+        AS_HELP_STRING([--disable-cracklib-check], [disable cracklib dictionary check]))
+
+AS_IF([test "x$enableval" != "xno"], [
 AC_CHECK_HEADERS([crack.h],
       AC_SEARCH_LIBS([FascistCheck], [crack], LIBCRACK="-lz -lcrack" LIBS="$LIBS -lz", LIBCRACK="", [-lz]))
 if test "x$LIBCRACK" = "x" ; then
     AC_MSG_ERROR([No or unusable cracklib library])
 fi
 AC_SUBST([LIBCRACK])
+])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_BIGENDIAN

--- a/src/check.c
+++ b/src/check.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#ifdef HAVE_CRACK_H
 #include <crack.h>
+#endif
 #include <sys/types.h>
 #include <pwd.h>
 #include <unistd.h>
@@ -710,6 +712,7 @@ pwquality_check(pwquality_settings_t *pwq, const char *password,
         if (score != 0)
                 return score;
 
+        #ifdef HAVE_CRACK_H
         if (pwq->dict_check) {
                 msg = FascistCheck(password, pwq->dict_path);
                 if (msg) {
@@ -718,6 +721,7 @@ pwquality_check(pwquality_settings_t *pwq, const char *password,
                         return PWQ_ERROR_CRACKLIB_CHECK;
                 }
         }
+        #endif
 
         score = password_score(pwq, password);
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -16,7 +16,9 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <limits.h>
+#ifdef HAVE_CRACK_H
 #include <crack.h>
+#endif
 #include <errno.h>
 
 #include "pwquality.h"

--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -47,7 +47,13 @@ struct setting_mapping {
 #define PWQ_DEFAULT_UP_CREDIT    0
 #define PWQ_DEFAULT_LOW_CREDIT   0
 #define PWQ_DEFAULT_OTH_CREDIT   0
+
+#ifdef HAVE_CRACK_H
 #define PWQ_DEFAULT_DICT_CHECK   1
+#else
+#define PWQ_DEFAULT_DICT_CHECK   0
+#endif
+
 #define PWQ_DEFAULT_USER_CHECK   1
 #define PWQ_DEFAULT_USER_SUBSTR  0
 #define PWQ_DEFAULT_ENFORCING    1

--- a/src/settings.c
+++ b/src/settings.c
@@ -13,7 +13,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <dirent.h>
+#ifdef HAVE_CRACK_H
 #include <crack.h>
+#endif
 
 #include "pwquality.h"
 #include "pwqprivate.h"
@@ -476,10 +478,14 @@ pwquality_get_str_value(pwquality_settings_t *pwq, int setting, const char **val
                 *value = pwq->bad_words;
                 break;
         case PWQ_SETTING_DICT_PATH:
+                #ifdef HAVE_CRACK_H
                 if (pwq->dict_path)
                         *value = pwq->dict_path;
                 else
                         *value = GetDefaultCracklibDict();
+                #else
+                        *value = NULL;
+                #endif
                 break;
         default:
                 return PWQ_ERROR_NON_STR_SETTING;


### PR DESCRIPTION
Check for cracklib by default but leave the option to disable it.

closes https://github.com/libpwquality/libpwquality/issues/4