### PR TITLE
Change "usersubstr" option to make it easier to understand

### DIFF
--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -209,7 +209,7 @@ than 3 characters.
 =item B<usersubstr=>I<N>
 
 If greater than 3 (due to the minimum length in usercheck), check whether the
-password contains a substring of at least I<N> length in some form.
+password contains a substring of the user name of at least I<N> length in some form.
 The default is 0, which means this check is disabled.
 
 =item B<enforcing=>I<N>


### PR DESCRIPTION
I was using the man page and it took me a bit to realize the usersubstr was referring to a substring of the user name.
This is minor but I feel it'll make it easier to understand it on first read.