### PR TITLE
pam_pwquality: add include for pam_modutil_check_user_in_passwd

### DIFF
--- a/src/pam_pwquality.c
+++ b/src/pam_pwquality.c
@@ -34,6 +34,10 @@
 #include <security/_pam_macros.h>
 #include <security/pam_ext.h>
 
+#ifdef HAVE_PAM_CHECK_USER_IN_PASSWD
+#include <security/pam_modutil.h>
+#endif
+
 /* argument parsing */
 #define PAM_DEBUG_ARG       0x0001
 


### PR DESCRIPTION
After 9084c1b032161cdb53d5f66132a91bdc207faecf, one gets:
```
pam_pwquality.c: In function 'check_local_user':
pam_pwquality.c:102:16: error: implicit declaration of function 'pam_modutil_check_user_in_passwd' [-Werror=implicit-function-declaration]
  102 |         return pam_modutil_check_user_in_passwd(pamh, user, NULL) == PAM_SUCCESS;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [Makefile:634: pam_pwquality.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
```

We need to include security/pam_modutil.h when appropriate.

Signed-off-by: Sam James <sam@gentoo.org>