### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/libpwquality.spec.in
+++ b/libpwquality.spec.in
@@ -33,9 +33,11 @@ BuildRequires: gettext
 BuildRequires: pam-devel
 %if %{with python2}
 BuildRequires: python2-devel
+BuildRequires: python2-setuptools
 %endif
 %if %{with python3}
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 %endif
 
 URL: https://github.com/libpwquality/libpwquality/
@@ -103,15 +105,6 @@ cp -a . %{py3dir}
 pushd %{py3dir}
 %endif
 %if %{with python3}
-# setuptools >= 60 changes the environment to use its bundled copy of distutils
-# by default, not the Python-bundled one. To run the Python's standard library
-# distutils, the environment variable must be set.
-# Although technically setuptools is not needed for this package, if it's
-# pulled by another package, it changes the environment and consequently,
-# the build fails. This was reported in:
-# https://github.com/pypa/setuptools/issues/3143
-export SETUPTOOLS_USE_DISTUTILS=stdlib
-
 %configure \
 	--with-securedir=%{_moduledir} \
 	--with-pythonsitedir=%{python3_sitearch} \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -14,7 +14,7 @@ all-local:
 	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV)
 
 install-exec-local:
-	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --prefix=${DESTDIR}${prefix}
+	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --root ${DESTDIR} --prefix=${prefix}
 
 clean-local:
 	rm -rf py$(PYTHONREV)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -6,9 +6,9 @@
 
 import os
 
-from distutils.core import setup, Extension
-from distutils.command.build_ext import build_ext as _build_ext
-from distutils.command.sdist import sdist as _sdist
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.command.sdist import sdist as _sdist
 
 def genconstants(headerfile, outputfile):
     hf = open(headerfile, 'r')


### PR DESCRIPTION
distutils is removed from Python 3.12+:
https://peps.python.org/pep-0632/