### PR TITLE
Make maxclassrepeat=1 behavior consistent with docs

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -238,7 +238,7 @@ simple(pwquality_settings_t *pwq, const char *new, void **auxerror)
                         } else
                                 sameclass++;
                 }
-                if (pwq->max_class_repeat > 1 && sameclass > pwq->max_class_repeat) {
+                if (pwq->max_class_repeat > 0 && sameclass > pwq->max_class_repeat) {
                         if (auxerror)
                                 *auxerror = (void *)(long)pwq->max_class_repeat;
                         return PWQ_ERROR_MAX_CLASS_REPEAT;


### PR DESCRIPTION
When setting maxclassrepeat=1, the rule would be inactive and allow passwords containing 2 consecutive characters from the same class. Only when setting maxclassrepeat>=2, the rule would behave as expected.

This issue was already addressed in pam_cracklib many years ago: https://github.com/linux-pam/linux-pam/pull/9