### PR TITLE
Support snippets in /usr/lib/security

### DIFF
--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -33,6 +33,8 @@ struct pwquality_settings {
         int local_users_only;
         char *bad_words;
         char *dict_path;
+        char *base_cfgfile;
+        char *default_cfgfile;
 };
 
 struct setting_mapping {
@@ -71,13 +73,20 @@ struct setting_mapping {
 #define PWQ_MIN_WORD_LENGTH      4
 #define PWQ_MAX_PASSWD_BUF_LEN   16300
 
-#ifndef PWQUALITY_BASE_CFGFILE
-#define PWQUALITY_BASE_CFGFILE "/usr/lib/security/pwquality.conf"
+#ifndef PWQUALITY_BASE_PATH
+#define PWQUALITY_BASE_PATH "/usr/lib"
 #endif
 
-#ifndef PWQUALITY_DEFAULT_CFGFILE
-#define PWQUALITY_DEFAULT_CFGFILE "/etc/security/pwquality.conf"
+#ifndef PWQUALITY_DEFAULT_PATH
+#define PWQUALITY_DEFAULT_PATH "/etc"
 #endif
+
+#ifndef PWQUALITY_DEFAULT_NAME
+#define PWQUALITY_DEFAULT_NAME "security/pwquality.conf"
+#endif
+
+#define PWQUALITY_BASE_CFGFILE PWQUALITY_BASE_PATH "/" PWQUALITY_DEFAULT_NAME
+#define PWQUALITY_DEFAULT_CFGFILE PWQUALITY_DEFAULT_PATH "/" PWQUALITY_DEFAULT_NAME
 
 #endif /* PWQPRIVATE_H */
 

--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -71,6 +71,10 @@ struct setting_mapping {
 #define PWQ_MIN_WORD_LENGTH      4
 #define PWQ_MAX_PASSWD_BUF_LEN   16300
 
+#ifndef PWQUALITY_BASE_CFGFILE
+#define PWQUALITY_BASE_CFGFILE "/usr/lib/security/pwquality.conf"
+#endif
+
 #ifndef PWQUALITY_DEFAULT_CFGFILE
 #define PWQUALITY_DEFAULT_CFGFILE "/etc/security/pwquality.conf"
 #endif

--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -93,6 +93,10 @@ int
 pwquality_read_config(pwquality_settings_t *pwq, const char *cfgfile,
         void **auxerror);
 
+/* Set the default configuration file for use by pwquality_read_config() */
+void
+pwquality_set_default_config_name(const char *cfgfile);
+
 /* Useful for setting the options as configured on a pam module
  * command line in form of <opt>=<val> */
 int

--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -93,9 +93,11 @@ int
 pwquality_read_config(pwquality_settings_t *pwq, const char *cfgfile,
         void **auxerror);
 
-/* Set the default configuration file for use by pwquality_read_config() */
-void
-pwquality_set_default_config_name(const char *cfgfile);
+/* Set the default configuration file name for use by pwquality_read_config().
+ * If cfgname is NULL set the options to their default values.
+ * Default: "security/pwquality.conf" */
+int
+pwquality_set_config_name(pwquality_settings_t *pwq, const char *cfgname);
 
 /* Useful for setting the options as configured on a pam module
  * command line in form of <opt>=<val> */


### PR DESCRIPTION
Fix #23 

I'm using `signed char` instead of `bool` because I wasn't sure if I should `#include <stdbool.h>`.