### PR TITLE
pwquality_generate(): Don't report CrackLib errors as 'low entropy'

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -105,6 +105,7 @@ pwquality_generate(pwquality_settings_t *pwq, int entropy_bits, char **password)
         char entropy[(PWQ_MAX_ENTROPY_BITS+PWQ_MAX_ENTROPY_BITS/9)/8 + 2];
         char *tmp;
         int maxlen;
+        int rv = 0;
         int try = 0;
 
         *password = NULL;
@@ -159,20 +160,23 @@ pwquality_generate(pwquality_settings_t *pwq, int entropy_bits, char **password)
                         *ptr = consonants1[idx];
                         ++ptr;
                 }
-        } while (pwquality_check(pwq, tmp, NULL, NULL, NULL) < 0 &&
+        } while ((rv = pwquality_check(pwq, tmp, NULL, NULL, NULL)) < 0 &&
                  ++try < PWQ_NUM_GENERATION_TRIES);
 
         /* clean up */
         memset(entropy, '\0', sizeof(entropy));
 
         if (try >= PWQ_NUM_GENERATION_TRIES) {
+                if (rv != PWQ_ERROR_CRACKLIB_CHECK)
+                        rv = PWQ_ERROR_GENERATION_FAILED;
+
                 free(tmp);
-                return PWQ_ERROR_GENERATION_FAILED;
+                return rv;
         }
 
         *password = tmp;
         tmp = NULL;
-        return 0;
+        return rv;
 }
 
 


### PR DESCRIPTION
If the CrackLib dictionaries were missing, `pwmake(1)` would complain that the entropy is too low:
```ShellSession
  $ pwmake 64
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  Error: Password generation failed - required entropy too low for
    settings
```
... and confuse users [1].

This changes it to report something closer to the truth:
```ShellSession
  $ pwmake 64
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  /usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  Error: The password fails the dictionary check
```
... so that users can help themselves by installing the CrackLib dictionaries.

[1] https://github.com/containers/toolbox/issues/1351