### PR TITLE
configure.ac: fix pam_modutil_check_user_in_passwd check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,8 @@ if test "$enable_pam" != "no"; then
       test $fail = 1 &&
         AC_MSG_ERROR([You must install the PAM development package in order to compile libpwquality])
   fi
-  AC_CHECK_FUNC(
+  AC_CHECK_LIB(
+    [pam],
     [pam_modutil_check_user_in_passwd],
     [AC_DEFINE([HAVE_PAM_CHECK_USER_IN_PASSWD], [], [have pam_modutil_check_user_in_passwd])],
     []


### PR DESCRIPTION
AC_CHECK_FUNC didn't link libpam, so the check would ~never succeed.