### PR TITLE
Remove redundant inclusion of libintl.h in pam_pwquality.c

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -164,7 +164,7 @@ pwquality_generate(pwquality_settings_t *pwq, int entropy_bits, char **password)
                  ++try < PWQ_NUM_GENERATION_TRIES);
 
         /* clean up */
-        memset(entropy, '\0', sizeof(entropy));
+        explicit_bzero(entropy, sizeof(entropy));
 
         if (try >= PWQ_NUM_GENERATION_TRIES) {
                 if (rv != PWQ_ERROR_CRACKLIB_CHECK)

--- a/src/pam_pwquality.c
+++ b/src/pam_pwquality.c
@@ -15,7 +15,6 @@
 #include <ctype.h>
 #include <limits.h>
 #include <syslog.h>
-#include <libintl.h>
 #include <stdio.h>
 #include <pwd.h>
 #include <errno.h>


### PR DESCRIPTION
The header file libintl.h has been included by config.h with macro ENABLE_NLS.It is redundant inclusion in pam_pwquality.