### PR TITLE
Remove redundant inclusion of libintl.h in pam_pwquality.c

### DIFF
--- a/src/pam_pwquality.c
+++ b/src/pam_pwquality.c
@@ -15,7 +15,6 @@
 #include <ctype.h>
 #include <limits.h>
 #include <syslog.h>
-#include <libintl.h>
 #include <stdio.h>
 #include <pwd.h>
 #include <errno.h>


### PR DESCRIPTION
The header file libintl.h has been included by config.h with macro ENABLE_NLS.It is redundant inclusion in pam_pwquality.

Fix #59 