### PR TITLE
Fix the error in handling the return value of the pwquality_generate function

### DIFF
--- a/src/pwmake.c
+++ b/src/pwmake.c
@@ -74,7 +74,7 @@ main(int argc, char *argv[])
         rv = pwquality_generate(pwq, (int)bits, &password);
         pwquality_free_settings(pwq);
 
-        if (rv != 0) {
+        if (rv < 0) {
                 fprintf(stderr, "Error: %s\n", pwquality_strerror(NULL, 0, rv, NULL));
                 exit(1);
         }


### PR DESCRIPTION
The commit aeff47d had changed the return value of pwquality_generate(). 
Now, the positive return value is the score of the password, not the error. 
Fix the issue like this:
$ pwmake 64
Error: Unknown error

Fix #100 