### PR TITLE
Effectively clear sensitive data memory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,12 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_LIBTOOL
 
+AC_CHECK_FUNCS(
+explicit_bzero
+memset_explicit
+memset_s
+)
+
 dnl and some hacks to use /etc
 test "${prefix}" = "NONE" && prefix="/usr"
 if test ${prefix} = '/usr'


### PR DESCRIPTION
Use explicit-bzero instead of memset to clear entropy memory.

Fix #92 