### PR TITLE
feat: add allowing / disabling classes of charachters

### DIFF
--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -254,6 +254,13 @@ This argument is used to I<force> the module to not prompt the user for
 a new password but use the one provided by the previously stacked
 B<password> module.
 
+=item B<allowclasses=>I<< "ludo" >>
+
+The list of letters, that represent allowed charachter classes,
+that are allowed in password (digits, uppercase, lowercase, others).
+"d" is for digits, "u" is for uppercase, "l" is for lowercase,
+"o" is for others.
+
 =back
 
 =head1 MODULE TYPES PROVIDED

--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -256,10 +256,10 @@ B<password> module.
 
 =item B<allowclasses=>I<< "ludo" >>
 
-The list of letters, that represent allowed charachter classes,
-that are allowed in password (digits, uppercase, lowercase, others).
-"d" is for digits, "u" is for uppercase, "l" is for lowercase,
-"o" is for others.
+The list of letters that represent allowed character classes that
+are allowed in a password (digits, uppercase, lowercase, others).
+"d" is for digits, "u" is for uppercase letters, "l" is for
+lowercase letters, "o" is for other characters.
 
 =back
 

--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -102,7 +102,7 @@ The maximum length of monotonic character sequences in the new password.
 Examples of such sequence are '12345' or 'fedcb'. Note
 that most such passwords will not pass the simplicity check unless
 the sequence is only a minor part of the password.
-The check is disabled if the value is 0. (default 0) 
+The check is disabled if the value is 0. (default 0)
 
 =item B<maxclassrepeat>
 
@@ -171,6 +171,12 @@ The module will not test the password quality for users that are not present
 in the F</etc/passwd> file. The module still asks for the password so
 the following modules in the stack can use the B<use_authtok> option.
 This option is off by default.
+
+=item B<allowclasses>
+
+The list of charachter classes, that are allowed in password (digits,
+uppercase, lowercase, others). "d" is for digits, "u" is for uppercase,
+"l" is for lowercase, "o" is for others. (default "ludo")
 
 =back
 

--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -174,9 +174,10 @@ This option is off by default.
 
 =item B<allowclasses>
 
-The list of charachter classes, that are allowed in password (digits,
-uppercase, lowercase, others). "d" is for digits, "u" is for uppercase,
-"l" is for lowercase, "o" is for others. (default "ludo")
+The list of letters that represent allowed character classes that
+are allowed in a password (digits, uppercase, lowercase, others).
+"d" is for digits, "u" is for uppercase letters, "l" is for
+lowercase letters, "o" is for other characters. (default "ludo")
 
 =back
 

--- a/src/check.c
+++ b/src/check.c
@@ -49,7 +49,7 @@ palindrome(const char *new)
  * the other
  */
 
-static int 
+static int
 distdifferent(const char *old, const char *new,
               size_t i, size_t j)
 {
@@ -243,6 +243,34 @@ simple(pwquality_settings_t *pwq, const char *new, void **auxerror)
                                 *auxerror = (void *)(long)pwq->max_class_repeat;
                         return PWQ_ERROR_MAX_CLASS_REPEAT;
                 }
+        }
+        if (digits > 0) {
+            if (strpbrk(pwq->allow_classes, "d") == NULL) {
+                if (auxerror)
+                    *auxerror = strdup("digits");
+                return PWQ_ERROR_DISALLOWED_CLASS;
+            }
+        }
+        if (uppers > 0) {
+            if (strpbrk(pwq->allow_classes, "u") == NULL) {
+                if (auxerror)
+                    *auxerror = strdup("uppercase");
+                return PWQ_ERROR_DISALLOWED_CLASS;
+            }
+        }
+        if (lowers > 0) {
+            if (strpbrk(pwq->allow_classes, "l") == NULL) {
+                if (auxerror)
+                    *auxerror = strdup("lowercase");
+                return PWQ_ERROR_DISALLOWED_CLASS;
+            }
+        }
+        if (others > 0) {
+            if (strpbrk(pwq->allow_classes, "o") == NULL) {
+                if (auxerror)
+                    *auxerror = strdup("other");
+                return PWQ_ERROR_DISALLOWED_CLASS;
+            }
         }
 
         if ((pwq->dig_credit >= 0) && (digits > pwq->dig_credit))

--- a/src/error.c
+++ b/src/error.c
@@ -149,6 +149,13 @@ pwquality_strerror(char *buf, size_t len, int rv, void *auxerror)
                 return _("The configuration file is malformed");
         case PWQ_ERROR_FATAL_FAILURE:
                 return _("Fatal failure");
+        case PWQ_ERROR_DISALLOWED_CLASS:
+                if (auxerror) {
+                    snprintf(buf, len, _("The %s class of characters is not allowed"), (const char *)auxerror);
+                    free(auxerror);
+                    return buf;
+                }
+                return _("The password contains disallowed character class");
         default:
                 return _("Unknown error");
         }
@@ -188,4 +195,3 @@ pwquality_strerror(char *buf, size_t len, int rv, void *auxerror)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 

--- a/src/generate.c
+++ b/src/generate.c
@@ -115,7 +115,7 @@ consume_entropy(char *buf, int bits, int *remaining, int *offset)
         }
 
         *offset += bits;
-        return low;    
+        return low;
 }
 
 /* generate a random password according to the settings */

--- a/src/pam_pwquality.c
+++ b/src/pam_pwquality.c
@@ -87,7 +87,7 @@ _pam_parse (pam_handle_t *pamh, struct module_options *opt,
                 } else if (!strncmp(*argv, "try_first_pass", 14)) {
                         /* for pam_get_authtok, ignore */;
                 } else if (pwquality_set_option(pwq, *argv)) {
-                        pam_syslog(pamh, LOG_ERR, 
+                        pam_syslog(pamh, LOG_ERR,
                                 "pam_parse: unknown or broken option; %s", *argv);
                 }
          }
@@ -212,7 +212,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags,
                         if (retval != PAM_SUCCESS || newtoken == NULL) {
                                 if (retval == PAM_AUTHTOK_ERR || newtoken == NULL)
                                         pam_syslog(pamh, LOG_INFO, "user aborted password change");
-                                else 
+                                else
                                         pam_syslog(pamh, LOG_ERR, "pam_get_authtok_noverify returned error: %s",
                                                pam_strerror(pamh, retval));
                                 pwquality_free_settings(options.pwq);
@@ -262,7 +262,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags,
                                         continue;
                                 if (retval == PAM_AUTHTOK_ERR || newtoken == NULL)
                                         pam_syslog(pamh, LOG_INFO, "user aborted password change");
-                                else 
+                                else
                                         pam_syslog(pamh, LOG_ERR, "pam_get_authtok_verify returned error: %s",
                                                pam_strerror(pamh, retval));
                                 pwquality_free_settings(options.pwq);

--- a/src/pwqprivate.h
+++ b/src/pwqprivate.h
@@ -35,6 +35,7 @@ struct pwquality_settings {
         char *dict_path;
         char *base_cfgfile;
         char *default_cfgfile;
+        char *allow_classes;
 };
 
 struct setting_mapping {
@@ -49,6 +50,7 @@ struct setting_mapping {
 #define PWQ_DEFAULT_UP_CREDIT    0
 #define PWQ_DEFAULT_LOW_CREDIT   0
 #define PWQ_DEFAULT_OTH_CREDIT   0
+#define PWQ_DEFAULT_ALLOWCLASSES "ludo"
 
 #ifdef HAVE_CRACK_H
 #define PWQ_DEFAULT_DICT_CHECK   1

--- a/src/pwquality.conf
+++ b/src/pwquality.conf
@@ -77,3 +77,7 @@
 # /etc/passwd file.
 # Enabled if the option is present.
 # local_users_only
+#
+# The allowed classes of characters (digits, uppercase, lowercase, others)
+# to be used in the password.
+# allowclasses = "ludo"

--- a/src/pwquality.conf
+++ b/src/pwquality.conf
@@ -58,6 +58,10 @@
 # The check is enabled if the value is greater than 0 and usercheck is enabled.
 # usersubstr = 0
 #
+# The allowed classes of characters (digits, uppercase, lowercase, others)
+# to be used in the password.
+# allowclasses = "ludo"
+#
 # Whether the check is enforced by the PAM module and possibly other
 # applications.
 # The new password is rejected if it fails the check and the value is not 0.
@@ -77,7 +81,3 @@
 # /etc/passwd file.
 # Enabled if the option is present.
 # local_users_only
-#
-# The allowed classes of characters (digits, uppercase, lowercase, others)
-# to be used in the password.
-# allowclasses = "ludo"

--- a/src/pwquality.h
+++ b/src/pwquality.h
@@ -36,6 +36,7 @@ extern "C" {
 #define PWQ_SETTING_ENFORCE_ROOT    19
 #define PWQ_SETTING_LOCAL_USERS     20
 #define PWQ_SETTING_USER_SUBSTR     21
+#define PWQ_SETTING_ALLOW_CLASSES   22
 
 #define PWQ_MAX_ENTROPY_BITS       256
 #define PWQ_MIN_ENTROPY_BITS       56
@@ -72,6 +73,7 @@ extern "C" {
 #define PWQ_ERROR_MAX_CLASS_REPEAT             -27
 #define PWQ_ERROR_BAD_WORDS                    -28
 #define PWQ_ERROR_MAX_SEQUENCE                 -29
+#define PWQ_ERROR_DISALLOWED_CLASS             -30
 
 typedef struct pwquality_settings pwquality_settings_t;
 
@@ -141,7 +143,7 @@ pwquality_generate(pwquality_settings_t *pwq, int entropy_bits,
  * is not returned.
  * Not passing the *auxerror into pwquality_strerror() can lead to memory leaks.
  * The score depends on PWQ_SETTING_MIN_LENGTH. If it is set higher,
- * the score for the same passwords will be lower. */ 
+ * the score for the same passwords will be lower. */
 int
 pwquality_check(pwquality_settings_t *pwq, const char *password,
         const char *oldpassword, const char *user, void **auxerror);

--- a/src/settings.c
+++ b/src/settings.c
@@ -25,15 +25,17 @@ pwquality_settings_t *
 pwquality_default_settings(void)
 {
         pwquality_settings_t *pwq;
-        char *base_cfgfile, *default_cfgfile;
+        char *base_cfgfile, *default_cfgfile, *allow_classes;
 
         pwq = calloc(1, sizeof(*pwq));
         base_cfgfile = strdup(PWQUALITY_BASE_CFGFILE);
         default_cfgfile = strdup(PWQUALITY_DEFAULT_CFGFILE);
-        if (!pwq || !base_cfgfile || !default_cfgfile) {
+        allow_classes = strdup(PWQ_DEFAULT_ALLOWCLASSES);
+        if (!pwq || !base_cfgfile || !default_cfgfile || !allow_classes) {
                 free(pwq);
                 free(base_cfgfile);
                 free(default_cfgfile);
+                free(allow_classes);
                 return NULL;
         }
 
@@ -52,6 +54,7 @@ pwquality_default_settings(void)
         pwq->local_users_only = PWQ_DEFAULT_LOCAL_USERS;
         pwq->base_cfgfile = base_cfgfile;
         pwq->default_cfgfile = default_cfgfile;
+        pwq->allow_classes = allow_classes;
 
         return pwq;
 }
@@ -65,6 +68,7 @@ pwquality_free_settings(pwquality_settings_t *pwq)
                 free(pwq->bad_words);
                 free(pwq->base_cfgfile);
                 free(pwq->default_cfgfile);
+                free(pwq->allow_classes);
                 free(pwq);
         }
 }
@@ -90,7 +94,8 @@ static const struct setting_mapping s_map[] = {
  { "dictpath", PWQ_SETTING_DICT_PATH, PWQ_TYPE_STR},
  { "retry", PWQ_SETTING_RETRY_TIMES, PWQ_TYPE_INT},
  { "enforce_for_root", PWQ_SETTING_ENFORCE_ROOT, PWQ_TYPE_SET},
- { "local_users_only", PWQ_SETTING_LOCAL_USERS, PWQ_TYPE_SET}
+ { "local_users_only", PWQ_SETTING_LOCAL_USERS, PWQ_TYPE_SET},
+ { "allowclasses", PWQ_SETTING_ALLOW_CLASSES, PWQ_TYPE_STR}
 };
 
 /* set setting name with value */
@@ -530,6 +535,10 @@ pwquality_set_str_value(pwquality_settings_t *pwq, int setting,
                 free(pwq->dict_path);
                 pwq->dict_path = dup;
                 break;
+        case PWQ_SETTING_ALLOW_CLASSES:
+                free(pwq->allow_classes);
+                pwq->allow_classes = dup;
+                break;
         default:
                 free(dup);
                 return PWQ_ERROR_NON_STR_SETTING;
@@ -620,6 +629,9 @@ pwquality_get_str_value(pwquality_settings_t *pwq, int setting, const char **val
                 #else
                         *value = NULL;
                 #endif
+                break;
+        case PWQ_SETTING_ALLOW_CLASSES:
+                *value = pwq->allow_classes;
                 break;
         default:
                 return PWQ_ERROR_NON_STR_SETTING;


### PR DESCRIPTION
The provided changes introduce an option of disabling specific character class for pam_pwquality.so.

The changes are based on the [discussion](https://github.com/libpwquality/libpwquality/discussions/96#discussioncomment-12235641).