### PR TITLE
Change commented default value for more consitency

### DIFF
--- a/doc/man/pam_pwquality.8.pod
+++ b/doc/man/pam_pwquality.8.pod
@@ -331,6 +331,6 @@ L<pam.conf(5)>, L<PAM(8)>
 
 =head1 AUTHORS
 
-Tomas Mraz <tmraz@redhat.com>
+Tomas Mraz <tm@t8m.info>
 
 Original author of B<pam_cracklib> module Cristian Gafton <gafton@redhat.com>

--- a/doc/man/pwmake.1.pod
+++ b/doc/man/pwmake.1.pod
@@ -51,4 +51,4 @@ L<pwscore(1)>, L<pam_pwquality(8)>
 
 =head1 AUTHORS
 
-Tomas Mraz <tmraz@redhat.com>
+Tomas Mraz <tm@t8m.info>

--- a/doc/man/pwquality.3.pod
+++ b/doc/man/pwquality.3.pod
@@ -138,4 +138,4 @@ L<pwquality.conf(5)>
 
 =head1 AUTHORS
 
-Tomas Mraz <tmraz@redhat.com>
+Tomas Mraz <tm@t8m.info>

--- a/doc/man/pwquality.conf.5.pod
+++ b/doc/man/pwquality.conf.5.pod
@@ -180,4 +180,4 @@ L<pwscore(1)>, L<pwmake(1)>, L<pam_pwquality(8)>
 
 =head1 AUTHORS
 
-Tomas Mraz <tmraz@redhat.com>
+Tomas Mraz <tm@t8m.info>

--- a/doc/man/pwscore.1.pod
+++ b/doc/man/pwscore.1.pod
@@ -48,4 +48,4 @@ L<pwscore(1)>, L<pwquality.conf(5)>, L<pam_pwquality(8)>
 
 =head1 AUTHORS
 
-Tomas Mraz <tmraz@redhat.com>
+Tomas Mraz <tm@t8m.info>

--- a/src/pwquality.conf
+++ b/src/pwquality.conf
@@ -67,7 +67,7 @@
 # dictpath =
 #
 # Prompt user at most N times before returning with error. The default is 1.
-# retry = 3
+# retry = 1
 #
 # Enforces pwquality checks on the root user password.
 # Enabled if the option is present.


### PR DESCRIPTION
Following the discussion in #114 I changed the documented value in [src/pwquality.conf](https://github.com/libpwquality/libpwquality/blob/master/src/pwquality.conf) to `# retry = 1`.

**Edit:** I added a second commit to this PR were I updated the email address of @t8m in the manpages to match the one found in [AUTHORS](https://github.com/Tronde/libpwquality/blob/master/AUTHORS).

Thank you in advance for considering this PR.