### PR TITLE
fix: sigsegv in allowclasses whit empty settings

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -202,6 +202,7 @@ simple(pwquality_settings_t *pwq, const char *new, void **auxerror)
         int others = 0;
         int size;
         int i;
+        const char *allow_classes;
         enum { NONE, DIGIT, UCASE, LCASE, OTHER } prevclass = NONE;
         int sameclass = 0;
 
@@ -244,29 +245,30 @@ simple(pwquality_settings_t *pwq, const char *new, void **auxerror)
                         return PWQ_ERROR_MAX_CLASS_REPEAT;
                 }
         }
+        pwquality_get_str_value(pwq, PWQ_SETTING_ALLOW_CLASSES, &allow_classes);
         if (digits > 0) {
-            if (strpbrk(pwq->allow_classes, "d") == NULL) {
+            if (strpbrk(allow_classes, "d") == NULL) {
                 if (auxerror)
                     *auxerror = strdup("digits");
                 return PWQ_ERROR_DISALLOWED_CLASS;
             }
         }
         if (uppers > 0) {
-            if (strpbrk(pwq->allow_classes, "u") == NULL) {
+            if (strpbrk(allow_classes, "u") == NULL) {
                 if (auxerror)
                     *auxerror = strdup("uppercase");
                 return PWQ_ERROR_DISALLOWED_CLASS;
             }
         }
         if (lowers > 0) {
-            if (strpbrk(pwq->allow_classes, "l") == NULL) {
+            if (strpbrk(allow_classes, "l") == NULL) {
                 if (auxerror)
                     *auxerror = strdup("lowercase");
                 return PWQ_ERROR_DISALLOWED_CLASS;
             }
         }
         if (others > 0) {
-            if (strpbrk(pwq->allow_classes, "o") == NULL) {
+            if (strpbrk(allow_classes, "o") == NULL) {
                 if (auxerror)
                     *auxerror = strdup("other");
                 return PWQ_ERROR_DISALLOWED_CLASS;

--- a/src/settings.c
+++ b/src/settings.c
@@ -631,7 +631,10 @@ pwquality_get_str_value(pwquality_settings_t *pwq, int setting, const char **val
                 #endif
                 break;
         case PWQ_SETTING_ALLOW_CLASSES:
-                *value = pwq->allow_classes;
+                if (pwq->allow_classes)
+                        *value = pwq->allow_classes;
+                else
+                        *value = PWQ_DEFAULT_ALLOWCLASSES;
                 break;
         default:
                 return PWQ_ERROR_NON_STR_SETTING;


### PR DESCRIPTION
Hi! 
Unfortunately in the #110 MR there was a bug. The program was failing with SIGSEGV, when the configuration file was empty. 
Fistly, I would like to apologies for not thinking thorughly about the edge case scenario. 
Secondly, I would like to offer the fix: in case the file in /pwquality.conf.d/* the `allowclasses = ` is empty, it ill opt out to the default settings.
How to reproduce:
create a conf file `/etc/security/pwquality.conf.d/test.conf` with `allowclasses = `.
Run 
```
./configure
make
echo "qwerty" | ./src/pwscore
```

